### PR TITLE
Support figwheel main builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ resources/private
 .nrepl-port
 .lein-failures
 yarn-error.log
+.cpcache/
+.rebel_readline_history

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,8 @@
+{:deps    {reagent                         {:mvn/version "0.10.0"
+                                            :exclusions  [cljsjs/react cljsjs/react-dom]}
+           com.bhauman/figwheel-main       {:mvn/version "0.2.11"}
+           com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
+           devcards                        {:mvn/version "0.2.7"}
+           com.fulcrologic/fulcro          {:mvn/version "3.3.5"}}
+ :paths   ["src/main" "src/cards" "resources" "target"]
+ :aliases {:fig {:main-opts ["-m" "figwheel.main" "-b" "dev" "-r"]}}}

--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,0 +1,3 @@
+^{:auto-bundle :webpack}
+{:main cljs-styled-components.cards
+ :devcards true}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "styled-components": "^5.1.0"
   },
   "devDependencies": {
-    "polished": "^3.5.1"
+    "polished": "^3.5.1",
+    "webpack": "^4.44.2",
+    "webpack-cli": "^3.3.12"
   },
   "scripts": {
     "start": "yarn shadow-cljs watch cards",

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                                          [thheller/shadow-cljs "2.8.94"]
                                          [thheller/shadow-cljsjs "0.0.21"]
                                          [reagent "0.10.0" :exclusions [cljsjs/react]]
-                                         [com.fulcrologic/fulcro "3.2.0"]
+                                         [com.fulcrologic/fulcro "3.3.5"]
                                          ;; using devcards 0.2.6 results in:
                                          ;failed to load devcards.system.js ReferenceError: React is not defined
                                          ;    at eval (system.cljs:321)

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="icon" href="https://clojurescript.org/images/cljs-logo-icon-32.png">
+    </head>
+    <body>
+        <div id="app"></div>
+        <!-- include your ClojureScript at the bottom of body like this -->
+        <script src="/cljs-out/dev/main_bundle.js" type="text/javascript"></script>
+    </body>
+</html>

--- a/src/main/cljs_styled_components/common.cljc
+++ b/src/main/cljs_styled_components/common.cljc
@@ -1,10 +1,11 @@
 (ns cljs-styled-components.common
   (:require
-    [clojure.string :as string]
-    #?@(:cljs
-        [["styled-components"
-          :refer [default keyframes ThemeProvider createGlobalStyle] :rename {default styled}]
-         ["react" :as react]])))
+   [clojure.string :as string]
+   #?@(:cljs
+       [["styled-components"
+         :as styled
+         :refer [keyframes ThemeProvider createGlobalStyle]]
+        ["react" :as react]])))
 
 #?(:cljs (goog-define DEBUG false))
 

--- a/src/main/cljs_styled_components/core.cljc
+++ b/src/main/cljs_styled_components/core.cljc
@@ -2,8 +2,7 @@
   (:require
     [cljs-styled-components.common :refer [keyword->css-str vconcat props-macro]]
     #?@(:cljs
-        [["styled-components" :refer [default keyframes ThemeProvider css createGlobalStyle]
-                              :rename {default styled}]
+        [["styled-components" :as styled :refer [keyframes ThemeProvider css createGlobalStyle]]
          ["react" :as react]
          [cljs-styled-components.common
           :refer
@@ -107,7 +106,7 @@
 ;; Without making a new Var the compiler will give a warning
 ;; Use of undeclared Var cljs-styled-components.core/styled
 
-#?(:cljs (def my-styled styled))
+#?(:cljs (def my-styled (.-default styled)))
 #?(:cljs (def my-keyframes keyframes))
 #?(:cljs (def my-css css))
 #?(:cljs (def my-createGlobalStyle createGlobalStyle))
@@ -176,4 +175,4 @@
 
 (defmacro sprops [ks body] (props-macro ks body))
 
-(macroexpand-1 '(sprops [hidden?] {:background (if hidden? "white" "black")}))
+#_(macroexpand-1 '(sprops [hidden?] {:background (if hidden? "white" "black")}))

--- a/src/main/cljs_styled_components/reagent.cljc
+++ b/src/main/cljs_styled_components/reagent.cljc
@@ -3,9 +3,9 @@
     [reagent.core :as r]
     [cljs-styled-components.common :refer [keyword->css-str vconcat props-macro]]
     #?@(:cljs
-        [["styled-components" :refer [default keyframes ThemeProvider css createGlobalStyle]
-                              :rename {default styled}]
+        [["styled-components" :as styled :refer [keyframes ThemeProvider css createGlobalStyle]]
          ["react" :as react]
+         [cljs-styled-components.core]
          [cljs-styled-components.common
           :refer
           [element? factory-apply theme-provider* clj-props* set-default-theme!* clj-props-key
@@ -127,7 +127,7 @@
 ;; Without making a new var the compiler will give a warning
 ;; Use of undeclared Var cljs-styled-components.reagent/styled
 
-#?(:cljs (def my-styled styled))
+#?(:cljs (def my-styled (.-default styled)))
 #?(:cljs (def my-keyframes keyframes))
 #?(:cljs (def my-css css))
 #?(:cljs (def my-createGlobalStyle createGlobalStyle))
@@ -186,4 +186,4 @@
        (my-css (cljs.core/array "" (str " " animation-params#)) kf-name#))))
 
 (defmacro sprops [ks body] (props-macro ks body))
-(macroexpand-1 '(sprops [hidden?] {:background (if hidden? "white" "black")}))
+#_(macroexpand-1 '(sprops [hidden?] {:background (if hidden? "white" "black")}))


### PR DESCRIPTION
Thanks so much for this library 🙇 

I was unable to to get this working with figwheel main as the "styled-components" npm dependency was not being resolved properly. I see that a [similar issue](https://github.com/dvingo/cljs-styled-components/issues/1) was raised before, but unfortunately it did not address the issue.

The changes included were tested with both shadow and figwheel main and seems to keep both builds happy and working. Unit tests as well as devcards work for both approaches with what is included. 

There is an [issue](https://github.com/fulcrologic/fulcro/issues/427) with fulcro that I raised while testing this, and they seem keen on addressing it. This should only affect figwheel main. It appears to be related to how figwheel main now levers cljs's `:target :bundle` option. 

I tried to add the bare minimum to get a simple way to test against figwheel main. To test:

```
$ clj -A:fig
```

Please let me know if I can include anything else or help in any way to get this merged 🙇 